### PR TITLE
1.21.9-1.21.10 Port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version '1.12-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -41,11 +41,11 @@ dependencies {
     // Recipe viewers
     //modCompileOnly "dev.emi:emi-fabric:${emi_version}"
     //modCompileOnly "dev.emi:emi-fabric:${project.emi_version}:api"
-    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
+    //modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
     modApi "me.shedaniel.cloth:basic-math:0.6.1"
 
     switch (recipe_viewer.toLowerCase(Locale.ROOT)) {
-        case "rei": modLocalRuntime("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"); break
+        //case "rei": modLocalRuntime("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"); break
         //case "emi": modLocalRuntime("dev.emi:emi-fabric:${project.emi_version}"); break
         case "disabled": break
         default: println("Unknown recipe viewer specified: $recipe_viewer. Must be EMI, REI or disabled.")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,22 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
-loader_version=0.17.2
+minecraft_version=1.21.9
+yarn_mappings=1.21.9+build.1
+loader_version=0.17.3
 
 # Mod Properties
-mod_version=1.5.0+1.21.6
+mod_version=1.5.0+1.21.9
 maven_group=de.dafuqs
 archives_base_name=fractal
 
 # Dependencies
 # check this on https://fabricmc.net/develop/
-fabric_api_version=0.128.2+1.21.6
+fabric_api_version=0.134.0+1.21.9
 
-rei_version=20.0.811
+#rei_version=20.0.811
 # emi dieded
 #emi_version=1.1.21+1.21.1
 
 # What recipe viewer to use ('emi', 'rei', or 'disabled')
-recipe_viewer=rei
+recipe_viewer=disabled

--- a/src/main/java/de/dafuqs/fractal/compat/FractalREIPlugin.java
+++ b/src/main/java/de/dafuqs/fractal/compat/FractalREIPlugin.java
@@ -1,4 +1,4 @@
-package de.dafuqs.fractal.compat;
+/*package de.dafuqs.fractal.compat;
 
 import de.dafuqs.fractal.interfaces.*;
 import de.dafuqs.fractal.mixin.client.*;
@@ -27,3 +27,4 @@ public class FractalREIPlugin implements REIClientPlugin {
 	}
 	
 }
+*/

--- a/src/main/java/de/dafuqs/fractal/mixin/client/CreativeInventoryScreenAddTabsMixin.java
+++ b/src/main/java/de/dafuqs/fractal/mixin/client/CreativeInventoryScreenAddTabsMixin.java
@@ -131,7 +131,9 @@ public abstract class CreativeInventoryScreenAddTabsMixin extends HandledScreen<
 	}
 	
 	@Inject(at = @At("HEAD"), method = "mouseClicked", cancellable = true)
-	public void fractal$mouseClicked(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> ci) {
+	public void fractal$mouseClicked(Click click, boolean doubled, CallbackInfoReturnable<Boolean> cir) {
+		double mouseX = click.x();
+		double mouseY = click.y();
 		ItemGroup selected = selectedTab;
 		if (selected instanceof ItemGroupParent parent && !parent.fractal$getChildren().isEmpty()) {
 			int x = fractal$x;
@@ -146,7 +148,7 @@ public abstract class CreativeInventoryScreenAddTabsMixin extends HandledScreen<
 					
 					this.scrollPosition = 0.0F;
 					this.handler.scrollItems(0.0F);
-					ci.setReturnValue(true);
+					cir.setReturnValue(true);
 					return;
 				}
 				y += 10;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,9 +14,6 @@
   "entrypoints": {
     "main": [
       "de.dafuqs.fractal.Fractal"
-    ],
-    "rei_client": [
-      "de.dafuqs.fractal.compat.FractalREIPlugin"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Ported it to 1.21.9 and tested 1.21.10 as well. Disabled the REI compatibility due to it not yet being updated to the copper age. The CreativeInventoryScreenAddTabsMixin has been slightly changed to fit the new mouseClicked method. Instead of mouseX and mouseY, there is a Click object, and two new variables are added to the mixin to just grab the mouse x and y from this object.
I don't exactly know how pull requests work, so I don't know how to make it target a new branch.