### PR TITLE
Update to 26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.14-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom' version '1.15-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -32,12 +32,10 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    //mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    mappings loom.officialMojangMappings()
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 
     // Recipe viewers
     //modCompileOnly "dev.emi:emi-fabric:${emi_version}"
@@ -54,7 +52,7 @@ dependencies {
 }
 
 loom {
-    accessWidenerPath = file("src/main/resources/fractal.accesswidener")
+    accessWidenerPath = file("src/main/resources/fractal.classtweaker")
 }
 
 processResources {
@@ -71,14 +69,14 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 21
+    it.options.release = 25
 }
 
 java {
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,17 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
-loader_version=0.18.3
+minecraft_version=26.1
+loader_version=0.18.5
 
 # Mod Properties
-mod_version=1.6.0+1.21.11
+mod_version=1.6.0+26.1
 maven_group=de.dafuqs
 archives_base_name=fractal
 
 # Dependencies
 # check this on https://fabricmc.net/develop/
-fabric_api_version=0.140.0+1.21.11
+fabric_api_version=0.144.3+26.1
 
 #rei_version=20.0.811
 # emi dieded

--- a/src/main/java/de/dafuqs/fractal/Fractal.java
+++ b/src/main/java/de/dafuqs/fractal/Fractal.java
@@ -40,7 +40,7 @@ public class Fractal implements ModInitializer {
 	
 	public static final Identifier GROUP_ID = Identifier.fromNamespaceAndPath("mymod", "main");
 	
-	public static final CreativeModeTab MAIN = FabricItemGroup.builder()
+	public static final CreativeModeTab MAIN = FabricCreativeModeTab.builder()
 			.icon(() -> new ItemStack(Blocks.REDSTONE_BLOCK))
 			.displayItems((itemDisplayParameters, output) -> {
 				for (CreativeSubTab subGroup : Fractal.MAIN.fractal$getChildren()) {

--- a/src/main/java/de/dafuqs/fractal/api/CreativeSubTab.java
+++ b/src/main/java/de/dafuqs/fractal/api/CreativeSubTab.java
@@ -1,7 +1,7 @@
 package de.dafuqs.fractal.api;
 
 import net.fabricmc.fabric.api.event.*;
-import net.fabricmc.fabric.api.itemgroup.v1.*;
+import net.fabricmc.fabric.api.creativetab.v1.*;
 import net.minecraft.core.registries.*;
 import net.minecraft.network.chat.*;
 import net.minecraft.resources.*;
@@ -73,8 +73,8 @@ public class CreativeSubTab extends CreativeModeTab {
 		// Convert the entries to lists
 		List<ItemStack> mutableDisplayStacks = new LinkedList<>(displayItems);
 		List<ItemStack> mutableSearchTabStacks = new LinkedList<>(displayItemsSearchTab);
-		FabricItemGroupEntries entries = new FabricItemGroupEntries(context, mutableDisplayStacks, mutableSearchTabStacks); // scary ApiStatus.Internal usage
-		
+		FabricCreativeModeTabOutput entries = new FabricCreativeModeTabOutput(context, mutableDisplayStacks, mutableSearchTabStacks); // scary ApiStatus.Internal usage
+
 		final Event<CreativeSubTabEvent.ModifyEntries> modifyEntriesEvent = CreativeSubTabEvent.modifyEntriesEvent(identifier);
 		
 		if (modifyEntriesEvent != null) {

--- a/src/main/java/de/dafuqs/fractal/api/CreativeSubTabEvent.java
+++ b/src/main/java/de/dafuqs/fractal/api/CreativeSubTabEvent.java
@@ -2,7 +2,7 @@ package de.dafuqs.fractal.api;
 
 import de.dafuqs.fractal.impl.*;
 import net.fabricmc.fabric.api.event.*;
-import net.fabricmc.fabric.api.itemgroup.v1.*;
+import net.fabricmc.fabric.api.creativetab.v1.*;
 import net.minecraft.resources.*;
 
 public final class CreativeSubTabEvent {
@@ -38,9 +38,9 @@ public final class CreativeSubTabEvent {
 		/**
 		 * Modifies the item group entries.
 		 * @param entries the entries
-		 * @see FabricItemGroupEntries
+		 * @see FabricCreativeModeTabOutput
 		 */
-		void modifyEntries(FabricItemGroupEntries entries);
+		void modifyEntries(FabricCreativeModeTabOutput entries);
 	}
 
 	@FunctionalInterface
@@ -49,8 +49,8 @@ public final class CreativeSubTabEvent {
 		 * Modifies the item group entries.
 		 * @param group the item group that is being modified
 		 * @param entries the entries
-		 * @see FabricItemGroupEntries
+		 * @see FabricCreativeModeTabOutput
 		 */
-		void modifyEntries(CreativeSubTab group, FabricItemGroupEntries entries);
+		void modifyEntries(CreativeSubTab group, FabricCreativeModeTabOutput entries);
 	}
 }

--- a/src/main/java/de/dafuqs/fractal/impl/client/SmallFontRenderer.java
+++ b/src/main/java/de/dafuqs/fractal/impl/client/SmallFontRenderer.java
@@ -5,7 +5,7 @@ import java.io.UncheckedIOException;
 
 import net.fabricmc.fabric.api.resource.v1.ResourceLoader;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.PackType;
@@ -22,7 +22,7 @@ public class SmallFontRenderer {
 	private static final Identifier SILVER_FNT = Identifier.fromNamespaceAndPath("fractal", "textures/gui/silver.fnt");
 	private static AngelFont SILVER;
 
-	public static void draw(GuiGraphics ctx, String str, int x, int y, boolean rtl, int textColor) {
+	public static void draw(GuiGraphicsExtractor ctx, String str, int x, int y, boolean rtl, int textColor) {
 		int[] codePoints = str.codePoints().toArray();
 		if (rtl) {
 			int hf = codePoints.length/2;
@@ -59,7 +59,7 @@ public class SmallFontRenderer {
 			} else {
 				if (!hasRegisteredReloader) {
 					hasRegisteredReloader = true;
-					ResourceLoader.get(PackType.CLIENT_RESOURCES).registerReloader(Identifier.fromNamespaceAndPath("fractal", "font_loader"), new Reloader());
+					ResourceLoader.get(PackType.CLIENT_RESOURCES).registerReloadListener(Identifier.fromNamespaceAndPath("fractal", "font_loader"), new Reloader());
 				}
 				if (SILVER == null) {
 					SILVER = Reloader.parse(Minecraft.getInstance().getResourceManager());

--- a/src/main/java/de/dafuqs/fractal/mixin/client/CreativeModeInventoryScreenAddTabsMixin.java
+++ b/src/main/java/de/dafuqs/fractal/mixin/client/CreativeModeInventoryScreenAddTabsMixin.java
@@ -42,9 +42,10 @@ public abstract class CreativeModeInventoryScreenAddTabsMixin extends AbstractCo
 	private int fractal$x, fractal$h; // left tabs
 	@Unique
 	private int fractal$x2, fractal$h2; // right tabs
-	
-	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen;renderTooltip(Lnet/minecraft/client/gui/GuiGraphics;II)V"))
-	public void fractal$render(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+
+	// Old
+	@Inject(method = "extractRenderState", at = @At(value = "TAIL"))
+	public void fractal$render(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
 		if (!(selectedTab instanceof ICreativeTabParent parent) || parent.fractal$getChildren().isEmpty()) return;
 		
 		var matrices = guiGraphics.pose();
@@ -54,12 +55,12 @@ public abstract class CreativeModeInventoryScreenAddTabsMixin extends AbstractCo
 		if (!selectedTab.showTitle()) {
 			CreativeModeTab child = parent.fractal$getSelectedChild();
 			var selected = selectedTab.getDisplayName();
-			guiGraphics.drawString(font, selected, 8, 6, CommonColors.DARK_GRAY, false);
+			guiGraphics.text(font, selected, 8, 6, CommonColors.DARK_GRAY, false);
 			int x = 8 + font.width(selected);
 			if (child != null) {
-				guiGraphics.drawString(font, " ", x, 6, CommonColors.DARK_GRAY, false);
+				guiGraphics.text(font, " ", x, 6, CommonColors.DARK_GRAY, false);
 				x += font.width(" ");
-				guiGraphics.drawString(font, child.getDisplayName(), x, 6, CommonColors.DARK_GRAY, false);
+				guiGraphics.text(font, child.getDisplayName(), x, 6, CommonColors.DARK_GRAY, false);
 			}
 		}
 

--- a/src/main/java/de/dafuqs/fractal/mixin/client/CreativeModeInventoryScreenCustomTextureMixin.java
+++ b/src/main/java/de/dafuqs/fractal/mixin/client/CreativeModeInventoryScreenCustomTextureMixin.java
@@ -25,14 +25,14 @@ public abstract class CreativeModeInventoryScreenCustomTextureMixin {
 	private CreativeModeTab fractal$renderedItemGroup;
 	
 	// BACKGROUND
-	@ModifyArg(method = "renderBg", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIFFIIII)V"))
+	@ModifyArg(method = "extractBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;blit(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIFFIIII)V"))
 	private Identifier injectCustomGroupTexture(Identifier original) {
 		CreativeSubTab subGroup = getSelectedSubGroup();
 		return (subGroup == null || subGroup.getStyle().backgroundTexture() == null) ? original : subGroup.getStyle().backgroundTexture();
 	}
 	
 	// SCROLLBAR
-	@ModifyArg(method = "renderBg", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIFFIIII)V"))
+	@ModifyArg(method = "extractBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;blit(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIFFIIII)V"))
 	private Identifier injectCustomScrollbarTexture(Identifier original) {
 		CreativeSubTab subGroup = getSelectedSubGroup();
 		if(subGroup != null) {
@@ -45,12 +45,13 @@ public abstract class CreativeModeInventoryScreenCustomTextureMixin {
 	}
 	
 	// ICON
-	@Inject(method = "renderTabButton", at = @At("HEAD"))
-	private void captureContextGroup(GuiGraphics guiGraphics, int i, int j, CreativeModeTab creativeModeTab, CallbackInfo ci) {
+	@Inject(method = "extractTabButton", at = @At("HEAD"))
+	private void captureContextGroup(GuiGraphicsExtractor graphics, int mouseX, int mouseY, CreativeModeTab creativeModeTab, CallbackInfo ci) {
 		this.fractal$renderedItemGroup = creativeModeTab;
 	}
-	
-	@ModifyArg(method = "renderTabButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blitSprite(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIII)V"))
+
+	// Old
+	@ModifyArg(method = "extractTabButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;blitSprite(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIII)V"))
 	private Identifier injectCustomTabTexture(Identifier original) {
 		CreativeSubTab subGroup = getRenderedSubGroup();
 		if(subGroup == null) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,21 +19,13 @@
   "mixins": [
     "fractal.mixins.json"
   ],
-  "accessWidener": "fractal.accesswidener",
+  "accessWidener": "fractal.classtweaker",
   "depends": {
     "minecraft": ">=${minecraft_version}",
     "fabricloader": "*",
     "fabric-api": "*"
   },
   "custom": {
-    "loom:injected_interfaces": {
-      "net/minecraft/class_1761": [
-        "de/dafuqs/fractal/interfaces/ICreativeTabParent"
-      ],
-      "net/minecraft/class_481": [
-        "de/dafuqs/fractal/interfaces/ISubTabLocation"
-      ]
-    },
     "modmenu": {
       "badges": [ "library" ]
     }

--- a/src/main/resources/fractal.classtweaker
+++ b/src/main/resources/fractal.classtweaker
@@ -1,4 +1,4 @@
-accessWidener	v1	named
+classTweaker	v1	official
 
 accessible method net/minecraft/world/item/CreativeModeTab <init> (Lnet/minecraft/world/item/CreativeModeTab$Row;ILnet/minecraft/world/item/CreativeModeTab$Type;Lnet/minecraft/network/chat/Component;Ljava/util/function/Supplier;Lnet/minecraft/world/item/CreativeModeTab$DisplayItemsGenerator;)V
 accessible class net/minecraft/world/item/CreativeModeTab$ItemDisplayBuilder
@@ -6,3 +6,6 @@ accessible field net/minecraft/world/item/CreativeModeTab$ItemDisplayParameters 
 accessible field net/minecraft/world/item/CreativeModeTab displayItemsGenerator Lnet/minecraft/world/item/CreativeModeTab$DisplayItemsGenerator;
 accessible field net/minecraft/world/item/CreativeModeTab displayItems Ljava/util/Collection;
 accessible field net/minecraft/world/item/CreativeModeTab displayItemsSearchTab Ljava/util/Set;
+
+transitive-inject-interface net/minecraft/world/item/CreativeModeTab de/dafuqs/fractal/interfaces/ICreativeTabParent
+transitive-inject-interface net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen de/dafuqs/fractal/interfaces/ISubTabLocation


### PR DESCRIPTION
The accesswidener is now a classtweaker, and interface injection is done through this now instead of the fabric.mod.json
The only change that might have an effect on how it works is that the invoked method that CreativeModeInventoryScreenAddTabsMixin.fractal$render targets doesn't get called and didn't look to have a replacement so is now injecting into the tail of extractRenderState. I did not notice any problems caused by this.